### PR TITLE
feat(version): Implement version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GIT_COMMIT := $(shell git rev-parse HEAD)
+BUILD_DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
+
 BIN_DIR := bin
 
 $(BIN_DIR):
@@ -26,13 +29,21 @@ fmt:
 .PHONY: build
 build: deps
 	@echo "Building morpher-agent..."
-	go build -o $(BIN_DIR)/morpher-agent main.go
+	@echo "GIT_COMMIT=$(GIT_COMMIT)"
+	@echo "BUILD_DATE=$(BUILD_DATE)"
+	go build -ldflags="-s -w -X morpher-agent/internal/version.GitCommit=$(GIT_COMMIT) -X morpher-agent/internal/version.BuildDate=$(BUILD_DATE)" -o $(BIN_DIR)/morpher-agent main.go
 	@echo "Done"
 
 # Run all tests.
 .PHONY: test
 test:
-	@echo "Running tests..."
+	go test -v ./...
+
+# Run tests with coverage.
+.PHONY: test-coverage
+test-coverage:
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
 
 # Clean up test artifacts.
 .PHONY: clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"morpher-agent/cmd/version"
+)
+
+var rootCmd = &cobra.Command{
+	Use:           "morpher-agent",
+	Short:         "Lightweight agent that collects VM information for migration",
+	Long:          `morpher-agent is a lightweight agent that collects VM information for migration.`,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		rootCmd.PrintErrf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.AddCommand(version.VersionCmd)
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"morpher-agent/internal/version"
+)
+
+// VersionCmd represents the version command.
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Long:  `Print the version number of morpher-agent.`,
+	Run:   runVersion,
+}
+
+func runVersion(_ *cobra.Command, _ []string) {
+	fmt.Print(version.GetVersionInfo())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module morpher-agent
 
 go 1.24.5
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,15 @@
+package version
+
+import "fmt"
+
+var (
+	// These variables are set during build time using ldflags.
+	Version   = "dev"     // Default to "dev" if not set during build.
+	GitCommit = "none"    // Default to "none" if not set during build.
+	BuildDate = "unknown" // Default to "unknown" if not set during build.
+)
+
+// GetVersionInfo returns formatted version information.
+func GetVersionInfo() string {
+	return fmt.Sprintf("Version: %s\nGit Commit: %s\nBuild Date: %s\n", Version, GitCommit, BuildDate)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	result := GetVersionInfo()
+
+	// Check that the result contains expected fields.
+	expectedFields := []string{
+		"Version:",
+		"Git Commit:",
+		"Build Date:",
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(result, field) {
+			t.Errorf("GetVersionInfo() should contain '%s'", field)
+		}
+	}
+
+	// Check that the result has the expected format (3 lines).
+	lines := strings.Split(strings.TrimSpace(result), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("GetVersionInfo() should return 3 lines, got %d", len(lines))
+	}
+
+	// Check that each line has the expected format.
+	for i, line := range lines {
+		if !strings.Contains(line, ": ") {
+			t.Errorf("Line %d should contain ': ', got '%s'", i+1, line)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
-import "fmt"
+import "morpher-agent/cmd"
 
 func main() {
-	fmt.Println("Hello morpher-vm!")
+	cmd.Execute()
 }


### PR DESCRIPTION
This pull request introduces a new versioning system for the `morpher-agent`, adds a CLI framework using Cobra, and updates the build process to inject version metadata into the binary. The changes improve maintainability and make it easier to track build information and provide a user-friendly command-line interface.

**Versioning and Build Metadata:**
* Added a new `internal/version/version.go` file to manage version, git commit, and build date variables, which are injected at build time via `ldflags`. Also includes a function to format and return version info.
* Updated the `Makefile` to set `GIT_COMMIT` and `BUILD_DATE` variables and pass them to the Go build process using `-ldflags`, ensuring the binary contains accurate build metadata. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R3) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L29-R46)

**Command-line Interface:**
* Introduced the Cobra CLI framework by updating `go.mod` and adding dependencies, and implemented a new root command in `cmd/root.go` with a `version` subcommand. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R4-R10) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR1-R29) [[3]](diffhunk://#diff-638f1a6c08b445854a22e46b58a13eebdf98812c604b98a956550bf4ddc6bec1R1-R21)
* Refactored `main.go` to use the new CLI entrypoint, replacing the previous static print statement.

**Testing:**
* Added a unit test for the version info formatting in `internal/version/version_test.go` to ensure output correctness.