### PR TITLE
feat(collect): extend system info with hostname and network interfaces

### DIFF
--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -11,6 +11,7 @@ import (
 )
 
 type OSInfo struct {
+	HostName      string `json:"hostname"`
 	Name          string `json:"name"`
 	Version       string `json:"version"`
 	KernelVersion string `json:"kernel_version"`
@@ -51,6 +52,7 @@ func CollectOS() (*OSInfo, error) {
 	var out OSInfo
 
 	if hi, err := host.Info(); err == nil {
+		out.HostName = hi.Hostname
 		out.Name = titleOrRaw(hi.Platform)
 		out.Version = hi.PlatformVersion
 		out.KernelVersion = hi.KernelVersion

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -141,7 +141,7 @@ func CollectNetwork() (*NetworkInfo, error) {
 	if ifaces, err := net.Interfaces(); err == nil {
 		out.Interfaces = make([]NetworkInterface, 0, len(ifaces))
 		for _, iface := range ifaces {
-			// IP addresses collection
+			// IP addresses collection.
 			var addrs []string
 			for _, addr := range iface.Addrs {
 				if addr.Addr == "" ||
@@ -152,7 +152,7 @@ func CollectNetwork() (*NetworkInfo, error) {
 				addrs = append(addrs, addr.Addr)
 			}
 
-			// Skip interfaces without addresses
+			// Skip interfaces without addresses.
 			if len(addrs) == 0 {
 				continue
 			}


### PR DESCRIPTION
This PR enhances the system info collection functionality by adding hostname and network interface details.

## Changes:
- Add hostname field to system info collection (9fc992a)
- Add network interfaces (excluding loopback, link-local, and inactive interfaces) (fe1b6c8)
- Fix comment punctuation to satisfy godot linter (ab5ccae)

## Example Output
```text
{
  "os": {
    "hostname": "example-host",
    "name": "Rocky",
    "version": "9.x",
    "kernel_version": "5.14.x"
  },

  ...

  "network": {
    "interfaces": [
      {
        "name": "lo",
        "hardware_addr": "",
        "mtu": 65536,
        "addrs": ["::1/128"]
      },
      {
        "name": "enp0s1",
        "hardware_addr": "02:00:00:00:00:01",
        "mtu": 1500,
        "addrs": [
          "192.0.2.10/24",
          "2001:db8::1/64"
        ]
      }
    ]
  }
}
```